### PR TITLE
chore: remove unsupported block types from the list of currently supported

### DIFF
--- a/packages/react-notion-custom/CONTRIBUTING-KR.md
+++ b/packages/react-notion-custom/CONTRIBUTING-KR.md
@@ -641,49 +641,41 @@ fetchNotionPage();
 
 현재 react-notion-custom에서 지원되는 Notion 블록 타입들의 목록입니다. 이 목록은 지속적으로 업데이트될 예정입니다.
 
-| Block Type               | 지원 여부 | Block Type Enum        | 비고 |
-| ------------------------ | --------- | ---------------------- | ---- |
-| Paragraph                | ✅ Yes    | `paragraph`            |      |
-| Heading 1                | ✅ Yes    | `heading_1`            |      |
-| Heading 2                | ✅ Yes    | `heading_2`            |      |
-| Heading 3                | ✅ Yes    | `heading_3`            |      |
-| Bulleted List Item       | ✅ Yes    | `bulleted_list_item`   |      |
-| Numbered List Item       | ✅ Yes    | `numbered_list_item`   |      |
-| To-do                    | ✅ Yes    | `to_do`                |      |
-| Toggle                   | ✅ Yes    | `toggle`               |      |
-| Quote                    | ✅ Yes    | `quote`                |      |
-| Callout                  | ✅ Yes    | `callout`              |      |
-| Equation                 | ❌ No     | `equation`             |      |
-| Code                     | ✅ Yes    | `code`                 |      |
-| Image                    | ❌ No     | `image`                |      |
-| Video                    | ✅ Yes    | `video`                |      |
-| Bookmark                 | ❌ No     | `bookmark`             |      |
-| Divider                  | ✅ Yes    | `divider`              |      |
-| Table                    | ✅ Yes    | `table`                |      |
-| Table Row                | ✅ Yes    | `table_row`            |      |
-| Column                   | ✅ Yes    | `column`               |      |
-| Column List              | ✅ Yes    | `column_list`          |      |
-| Audio                    | ❌ No     | `audio`                |      |
-| Synced Block             | ❌ No     | `synced_block`         |      |
-| Table Of Contents        | ❌ No     | `table_of_contents`    |      |
-| Embed                    | ❌ No     | `embed`                |      |
-| Figma                    | ❌ No     | `figma`                |      |
-| Google Maps              | ❌ No     | `maps`                 |      |
-| Google Drive             | ❌ No     | `drive`                |      |
-| Tweet                    | ❌ No     | `tweet`                |      |
-| PDF                      | ❌ No     | `pdf`                  |      |
-| File                     | ❌ No     | `file`                 |      |
-| Link                     | ❌ No     | `text` (inline)        |      |
-| Page Link                | ❌ No     | `page`                 |      |
-| External Page Link       | ❌ No     | `text` (inline)        |      |
-| Collections              | ❌ No     | -                      |      |
-| Collection View          | ❌ No     | `collection_view`      |      |
-| Collection View Table    | ❌ No     | `collection_view`      |      |
-| Collection View Gallery  | ❌ No     | `collection_view`      |      |
-| Collection View Board    | ❌ No     | `collection_view`      |      |
-| Collection View List     | ❌ No     | `collection_view`      |      |
-| Collection View Calendar | ❌ No     | `collection_view`      |      |
-| Collection View Page     | ❌ No     | `collection_view_page` |      |
+| Block Type         | 지원 여부 | Block Type Enum      | 비고 |
+| ------------------ | --------- | -------------------- | ---- |
+| Paragraph          | ✅ Yes    | `paragraph`          |      |
+| Heading 1          | ✅ Yes    | `heading_1`          |      |
+| Heading 2          | ✅ Yes    | `heading_2`          |      |
+| Heading 3          | ✅ Yes    | `heading_3`          |      |
+| Bulleted List Item | ✅ Yes    | `bulleted_list_item` |      |
+| Numbered List Item | ✅ Yes    | `numbered_list_item` |      |
+| To-do              | ✅ Yes    | `to_do`              |      |
+| Toggle             | ✅ Yes    | `toggle`             |      |
+| Quote              | ✅ Yes    | `quote`              |      |
+| Callout            | ✅ Yes    | `callout`            |      |
+| Equation           | ❌ No     | `equation`           |      |
+| Code               | ✅ Yes    | `code`               |      |
+| Image              | ❌ No     | `image`              |      |
+| Video              | ✅ Yes    | `video`              |      |
+| Bookmark           | ❌ No     | `bookmark`           |      |
+| Divider            | ✅ Yes    | `divider`            |      |
+| Table              | ✅ Yes    | `table`              |      |
+| Table Row          | ✅ Yes    | `table_row`          |      |
+| Column             | ✅ Yes    | `column`             |      |
+| Column List        | ✅ Yes    | `column_list`        |      |
+| Audio              | ❌ No     | `audio`              |      |
+| Synced Block       | ❌ No     | `synced_block`       |      |
+| Table Of Contents  | ❌ No     | `table_of_contents`  |      |
+| Embed              | ❌ No     | `embed`              |      |
+| Figma              | ❌ No     | `figma`              |      |
+| Google Maps        | ❌ No     | `maps`               |      |
+| Google Drive       | ❌ No     | `drive`              |      |
+| Tweet              | ❌ No     | `tweet`              |      |
+| PDF                | ❌ No     | `pdf`                |      |
+| File               | ❌ No     | `file`               |      |
+| Link               | ❌ No     | `text` (inline)      |      |
+| Page Link          | ❌ No     | `page`               |      |
+| External Page Link | ❌ No     | `text` (inline)      |      |
 
 현재 모든 블록 타입이 지원되지 않고 있습니다 (❌ No). 이 프로젝트는 개발 초기 단계에 있으며, 향후 업데이트를 통해 점진적으로 더 많은 블록 타입을 지원할 예정입니다.
 

--- a/packages/react-notion-custom/CONTRIBUTING.md
+++ b/packages/react-notion-custom/CONTRIBUTING.md
@@ -644,49 +644,41 @@ Through this method, you can fetch Notion page data and use it with react-notion
 
 Here's a list of Notion block types currently supported in react-notion-custom. This list will be continuously updated.
 
-| Block Type               | Support Status | Block Type Enum        | Note |
-| ------------------------ | -------------- | ---------------------- | ---- |
-| Paragraph                | ✅ Yes         | `paragraph`            |      |
-| Heading 1                | ✅ Yes         | `heading_1`            |      |
-| Heading 2                | ✅ Yes         | `heading_2`            |      |
-| Heading 3                | ✅ Yes         | `heading_3`            |      |
-| Bulleted List Item       | ✅ Yes         | `bulleted_list_item`   |      |
-| Numbered List Item       | ✅ Yes         | `numbered_list_item`   |      |
-| To-do                    | ✅ Yes         | `to_do`                |      |
-| Toggle                   | ✅ Yes         | `toggle`               |      |
-| Quote                    | ✅ Yes         | `quote`                |      |
-| Callout                  | ✅ Yes         | `callout`              |      |
-| Equation                 | ❌ No          | `equation`             |      |
-| Code                     | ✅ Yes         | `code`                 |      |
-| Image                    | ❌ No          | `image`                |      |
-| Video                    | ✅ Yes         | `video`                |      |
-| Bookmark                 | ❌ No          | `bookmark`             |      |
-| Divider                  | ✅ Yes         | `divider`              |      |
-| Table                    | ✅ Yes         | `table`                |      |
-| Table Row                | ✅ Yes         | `table_row`            |      |
-| Column                   | ✅ Yes         | `column`               |      |
-| Column List              | ✅ Yes         | `column_list`          |      |
-| Audio                    | ❌ No          | `audio`                |      |
-| Synced Block             | ❌ No          | `synced_block`         |      |
-| Table Of Contents        | ❌ No          | `table_of_contents`    |      |
-| Embed                    | ❌ No          | `embed`                |      |
-| Figma                    | ❌ No          | `figma`                |      |
-| Google Maps              | ❌ No          | `maps`                 |      |
-| Google Drive             | ❌ No          | `drive`                |      |
-| Tweet                    | ❌ No          | `tweet`                |      |
-| PDF                      | ❌ No          | `pdf`                  |      |
-| File                     | ❌ No          | `file`                 |      |
-| Link                     | ❌ No          | `text` (inline)        |      |
-| Page Link                | ❌ No          | `page`                 |      |
-| External Page Link       | ❌ No          | `text` (inline)        |      |
-| Collections              | ❌ No          | -                      |      |
-| Collection View          | ❌ No          | `collection_view`      |      |
-| Collection View Table    | ❌ No          | `collection_view`      |      |
-| Collection View Gallery  | ❌ No          | `collection_view`      |      |
-| Collection View Board    | ❌ No          | `collection_view`      |      |
-| Collection View List     | ❌ No          | `collection_view`      |      |
-| Collection View Calendar | ❌ No          | `collection_view`      |      |
-| Collection View Page     | ❌ No          | `collection_view_page` |      |
+| Block Type         | Support Status | Block Type Enum      | Note |
+| ------------------ | -------------- | -------------------- | ---- |
+| Paragraph          | ✅ Yes         | `paragraph`          |      |
+| Heading 1          | ✅ Yes         | `heading_1`          |      |
+| Heading 2          | ✅ Yes         | `heading_2`          |      |
+| Heading 3          | ✅ Yes         | `heading_3`          |      |
+| Bulleted List Item | ✅ Yes         | `bulleted_list_item` |      |
+| Numbered List Item | ✅ Yes         | `numbered_list_item` |      |
+| To-do              | ✅ Yes         | `to_do`              |      |
+| Toggle             | ✅ Yes         | `toggle`             |      |
+| Quote              | ✅ Yes         | `quote`              |      |
+| Callout            | ✅ Yes         | `callout`            |      |
+| Equation           | ❌ No          | `equation`           |      |
+| Code               | ✅ Yes         | `code`               |      |
+| Image              | ❌ No          | `image`              |      |
+| Video              | ✅ Yes         | `video`              |      |
+| Bookmark           | ❌ No          | `bookmark`           |      |
+| Divider            | ✅ Yes         | `divider`            |      |
+| Table              | ✅ Yes         | `table`              |      |
+| Table Row          | ✅ Yes         | `table_row`          |      |
+| Column             | ✅ Yes         | `column`             |      |
+| Column List        | ✅ Yes         | `column_list`        |      |
+| Audio              | ❌ No          | `audio`              |      |
+| Synced Block       | ❌ No          | `synced_block`       |      |
+| Table Of Contents  | ❌ No          | `table_of_contents`  |      |
+| Embed              | ❌ No          | `embed`              |      |
+| Figma              | ❌ No          | `figma`              |      |
+| Google Maps        | ❌ No          | `maps`               |      |
+| Google Drive       | ❌ No          | `drive`              |      |
+| Tweet              | ❌ No          | `tweet`              |      |
+| PDF                | ❌ No          | `pdf`                |      |
+| File               | ❌ No          | `file`               |      |
+| Link               | ❌ No          | `text` (inline)      |      |
+| Page Link          | ❌ No          | `page`               |      |
+| External Page Link | ❌ No          | `text` (inline)      |      |
 
 Currently, not all block types are supported (❌ No). This project is in its early stages of development, and we plan to gradually support more block types through future updates.
 


### PR DESCRIPTION
# Description of Changes

Here is reference: #25

---

## remove `unsupported block types` from the list of currently supported
<img width="400px" src="https://github.com/user-attachments/assets/c4f19bd7-8215-4859-b39b-956ebd580353"/>

- Currently, for all collection-related Notion block types, the Enum is set to `collection_view`, which indicates a need for more specific `Block Type Enums`. (Please refer to attached photo)
- After checking [the official Notion API](https://developers.notion.com/reference/block#keys), we confirmed that Collections are not supported as block concepts in the Notion API.
- In our meeting, it was decided that **we plan to support Collections in the future**, so I've updated the documentation to reflect this.
- Also updated this information in the [Supported Notion Block Types Progress issue](https://github.com/meursyphus/react-notion-custom/issues/55).

## Review point
- I've already removed the collection-related items from the markdown file, but I'm curious about your opinion on whether we need a separate note or explanation for this removal. What do you think?
